### PR TITLE
Fix memory leak in case realloc() returns NULL

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -351,16 +351,23 @@ static void strappf(char **old, size_t *old_size, size_t *old_offset, const char
 
 	if (new_offset >= new_size)
 	{
+		char *renew;
+
 		new_size = new_offset + 1;
 
-		if (NULL != (new = realloc(new, new_size)))
+		if (NULL != (renew = realloc(new, new_size)))
 		{
+			new = renew;
 			va_start(args, format);
 			vsnprintf(new + *old_offset, new_size - *old_offset, format, args);
 			va_end(args);
 		}
 		else
+		{
+			free(new);
+			new = NULL;
 			new_size = new_offset = 0;
+		}
 	}
 
 	*old = new;


### PR DESCRIPTION
Memory pointed by `new` will become unreachable if `realloc()` call fails. In this case instead of freeing old buffer and returning a pointer to a new one, `realloc()` returns `NULL` which we immediately assign to `new`, thus overwriting pointer to an old buffer and losing ability to `free()` it. Memory shortage should be quite rare in real life and so the impact of the defect is quite low.