### PR TITLE
Force docker-compose version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 
 before_install:
+  - docker-compose --version
   - ./autogen.sh
   - python -m pip install -q --user pytest
   - ./configure --enable-zabbix-${ZBX_HEADERS_VERSION} -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ services:
   - docker
 
 before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
   - docker-compose --version
   - ./autogen.sh
   - python -m pip install -q --user pytest


### PR DESCRIPTION
This change installs a desired `docker-compose` version in Travis CI environment as described [here](https://docs.travis-ci.com/user/docker/#using-docker-compose). For now it will be [1.23.2](https://github.com/docker/compose/releases/1.23.2) which fixes container naming:
> Reverted a 1.23.0 change that appended random strings to container names
created by `docker-compose up`, causing addressability issues.