### PR TITLE
Add gitpod config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ compile
 # python tests
 **/.pytest_cache
 *.pyc
+
+# Compilation database
+compile_commands.json

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,6 +2,6 @@ FROM gitpod/workspace-full
                     
 USER gitpod
 
-RUN sudo apt-get -q update &&
-    sudo apt-get install -yq autoconf automake libtool pkg-config bear &&
+RUN sudo apt-get -q update && \
+    sudo apt-get install -yq autoconf automake libtool pkg-config bear && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+RUN sudo apt-get -q update &&
+    sudo apt-get install -yq autoconf automake libtool pkg-config bear &&
+    sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+- init: >-
+    autogen.sh &&
+    ./configure --prefix=/etc/zabbix --enable-zabbix-3.2 &&
+    bear make
+image:
+  file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
 - init: >-
-    autogen.sh &&
+    ./autogen.sh &&
     ./configure --prefix=/etc/zabbix --enable-zabbix-3.2 &&
     bear make
 image:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # libzbxmodbus
 [![Build Status](https://travis-ci.org/v-zhuravlev/libzbxmodbus.svg?branch=master)](https://travis-ci.org/v-zhuravlev/libzbxmodbus)  
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/v-zhuravlev/libzbxmodbus)
+
 This is the [Loadable module](https://www.zabbix.com/documentation/4.0/manual/config/items/loadablemodules) that adds support for Modbus (TCP, RTU and "RTU over TCP" (encapsulated)) in Zabbix.
 
 This module features:


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.