### PR TITLE
Make it possible to run unit tests in Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ aclocal.m4
 config.guess
 config.h
 config.h.in
+config.log
 config.status
 config.sub
 configure
@@ -59,6 +60,7 @@ stamp-h1
 src/.libs/
 ar-lib
 compile
+autom4te.cache
 
 # python tests
 **/.pytest_cache

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,5 +3,5 @@ FROM gitpod/workspace-full
 USER gitpod
 
 RUN sudo apt-get -q update && \
-    sudo apt-get install -yq autoconf automake libtool pkg-config bear && \
+    sudo apt-get install -yq autoconf automake libtool pkg-config bear python-pytest && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,5 +14,6 @@
 ## Run local
 You can run tests local:
 1. Build libzbxmodbus `./configure --enable-zabbix-3.2 && make`
+1. Make sure Docker is running. In Gitpod run `sudo docker-up` and open a new terminal.
 2. Build and run the rest with docker-compose `export ZBX_VERSION=3.4.12 ; pushd tests/docker && docker-compose build && docker-compose up -d --force-recreate`
 3. Run sample test from shell `docker-compose exec zabbix-agent-modbus sh -c "zabbix_get -s localhost -k modbus_read[172.16.238.2:5020,1,2,3,i,1,1]"`

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         - ZBX_VERSION=${ZBX_VERSION}
     volumes:
         - ../../src/.libs:/var/lib/zabbix/modules:ro
+    environment:
+      ZBX_PASSIVESERVERS: 127.0.0.1,::1
     ports:
      - "10050:10050"
     depends_on: 


### PR DESCRIPTION
With these changes it should be possible to run unit tests in Gitpod environment, i.e. there will be less pressure on Travis CI.

I've also added some generated stuff to git ignore list. This should also improve user experience for Gitpod environments, because Gitpod will no longer highlight workspaces with changes in those files.