### PR TITLE
Update version of Docker Compose file

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
  zabbix-agent-modbus:
     image: zabbix/zabbix-agent:ubuntu-${ZBX_VERSION-3.4.12}


### PR DESCRIPTION
Looks like default values for variables require 2.1:
https://docs.docker.com/compose/release-notes/#new-features-15