### PR TITLE
Simplify quoting by passing item key verbatim

### DIFF
--- a/tests/test_modbus_datatype_errors.py
+++ b/tests/test_modbus_datatype_errors.py
@@ -39,13 +39,12 @@ class TestModbusDatatypeErrors(object):
         assert zabbix_get(key) ==  'ZBX_NOTSUPPORTED: Datatype expression can neither begin nor end with skipping.'
 
     def test_modbus_datatype_skip_2(self, host):
-        formula = "'  skip   '"
+        formula = "  skip   "
         key = "modbus_read_registers["+host+",1,2,3,"+formula+"]"
         assert zabbix_get(key) ==  'ZBX_NOTSUPPORTED: Datatype expression can neither begin nor end with skipping.'
 
-    @pytest.mark.skip("Requires shell escaping")
     def test_modbus_datatype_whitespace_0(self, host):
-        formula = "\'\"    \"\'"
+        formula = "\"    \""
         key = "modbus_read_registers["+host+",1,2,3,"+formula+"]"
         assert zabbix_get(key) ==  'ZBX_NOTSUPPORTED: Unexpected end of the datatype expression.'
     

--- a/tests/test_modbus_datatype_expressions.py
+++ b/tests/test_modbus_datatype_expressions.py
@@ -120,7 +120,7 @@ class TestModbusBulk(object):
         assert json.loads(str_from_zabbix) == expected_json
 
     def test_modbus_bulk_BE_with_whitespace(self, host):
-        formula = "\' 1*int32 + 1*uint64 \'"
+        formula = " 1*int32 + 1*uint64 "
         first_reg = "12"
         key = "modbus_read["+host+",1,"+first_reg+",3,"+formula+",BE]"
         expected_json = json.loads("""

--- a/tests/zabbix_get.py
+++ b/tests/zabbix_get.py
@@ -2,7 +2,7 @@ import subprocess
 from os.path import abspath, dirname, join
 
 def zabbix_get(key):
-    batchcmd = ["docker-compose", "exec", "-T", "zabbix-agent-modbus", "sh", "-c", "zabbix_get -s localhost -k" + key]
+    batchcmd = ["docker-compose", "exec", "-T", "zabbix-agent-modbus", "zabbix_get", "-s", "localhost", "-k", key]
     directory = join(dirname(abspath(__file__)), "docker")
     result = subprocess.check_output(batchcmd, cwd=directory)
     return result.rstrip()


### PR DESCRIPTION
The idea is to eliminate shell invocation in `docker-compose exec`. Together with passing a list of parameters (instead of string) to `subprocess.check_output()` this ensures that item key is not subjected to parsing by any shell. In turn, this allows us to remove extra single quotes in unit tests, which wouldn't be there in item configuration in Zabbix.